### PR TITLE
Fix for empty events after filtering

### DIFF
--- a/src/sixte/simulator.py
+++ b/src/sixte/simulator.py
@@ -27,7 +27,7 @@ def run_simulation(
     rollangle: float = 0.0,
     sim_separate_ccds: bool = False,
     consume_data: bool = True,
-):
+) -> list[tuple[Path, int]] | None:
     xml_file = get_xml_file(
         xml_dir=xml_dir,
         instrument_name=instrument_name,
@@ -56,7 +56,13 @@ def run_simulation(
 
     evt_filepaths = []
     for evt_filepath in run_dir.glob("*_none"):
-        evt_filepaths.append(filter_event_pattern(eventlist_path=evt_filepath, max_event_pattern=max_event_pattern))
+        evt_filepath = filter_event_pattern(eventlist_path=evt_filepath, max_event_pattern=max_event_pattern)
+        if evt_filepath is not None:
+            evt_filepaths.append(evt_filepath)
+
+    if not evt_filepath:
+        logger.warning(f"No events have been detected for detector {instrument_name} for {simput_path}!")
+        return None
 
     merged = merge_ccd_eventlists(evt_filepaths, run_dir, consume_data)
 
@@ -173,6 +179,9 @@ def run_xmm_simulation(
             sim_separate_ccds=sim_separate_ccds,
             consume_data=consume_data,
         )
+
+        if tmp_split_img_paths_exps is None:
+            return
 
         for p in tmp_split_img_paths_exps:
             file_path: Path = p[0]

--- a/src/xmm_utils/file_utils.py
+++ b/src/xmm_utils/file_utils.py
@@ -24,12 +24,12 @@ def compress_targz(in_path: Path, out_file_path: Path, remove_files: bool = Fals
     )
 
 
-def decompress_targz(in_file_path: Path, out_file_dir: Path):
+def decompress_targz(in_file_path: Path, out_file_dir: Path, tar_options: str = ""):
     out_file_dir.mkdir(parents=True, exist_ok=True)
-    run_command(f"tar -xzf {in_file_path.resolve()} -C {out_file_dir.resolve()} --strip-components=1")
+    run_command(f"tar -xzf {in_file_path.resolve()} -C {out_file_dir.resolve()} {tar_options}")
 
 
-def filter_event_pattern(eventlist_path: Path, max_event_pattern: int):
+def filter_event_pattern(eventlist_path: Path, max_event_pattern: int) -> Path | None:
     if max_event_pattern == -1 or max_event_pattern == 12:
         # Use all event patterns
         return eventlist_path
@@ -42,6 +42,10 @@ def filter_event_pattern(eventlist_path: Path, max_event_pattern: int):
 
         # Filter the events data, remove every event with pattern type > max pattern type
         filtered_events_data = events_data[events_data["TYPE"] <= max_event_pattern]
+
+        if filtered_events_data.size == 0:
+            # No events left after filtering
+            return None
 
         # Since we filtered the events, set the patterns to 0
         for i in range(max_event_pattern + 1, 13):


### PR DESCRIPTION
After filtering for a specific event pattern, it is possible that no events are left. If so, skip further steps in generation and ignore the used SIMPUT.