### PR TITLE
Error in SIMPUT generation

### DIFF
--- a/02_generate_simput.py
+++ b/02_generate_simput.py
@@ -260,6 +260,7 @@ def run(path_to_cfg: Path, agn_counts_file: Path | None, spectrum_dir: Path | No
                     settings: dict = dict(simput_cfg.agn).copy()
                     settings["agn_counts_file"] = agn_counts_file
                     settings["instrument_name"] = instrument
+                    settings["n_gen"] = simput_cfg.agn.n_gen
                     if instrument == "epn" and sim_separate_ccds:
                         from src.xmm.epn import get_cc12_txy, get_plate_scale_xy
 
@@ -268,13 +269,6 @@ def run(path_to_cfg: Path, agn_counts_file: Path | None, spectrum_dir: Path | No
                         settings["center_point"] = (cc12_tx * (plate_scale_x / 3600), cc12_ty * (plate_scale_y / 3600))
                     else:
                         settings["center_point"] = (0, 0)
-
-                    if env_cfg.debug:
-                        settings["n_gen"] = simput_cfg.agn.n_gen
-                        kwds = ({"img_settings": settings} for _ in range(1))
-                    else:
-                        settings["n_gen"] = 1
-                        kwds = ({"img_settings": settings} for _ in range(simput_cfg.agn.n_gen))
 
                     img_settings.append(settings)
 

--- a/02_generate_simput.py
+++ b/02_generate_simput.py
@@ -260,7 +260,7 @@ def run(path_to_cfg: Path, agn_counts_file: Path | None, spectrum_dir: Path | No
                     settings: dict = dict(simput_cfg.agn).copy()
                     settings["agn_counts_file"] = agn_counts_file
                     settings["instrument_name"] = instrument
-                    settings["n_gen"] = simput_cfg.agn.n_gen
+                    settings["n_gen"] = simput_cfg.agn.n_gen if env_cfg.debug else 1
                     if instrument == "epn" and sim_separate_ccds:
                         from src.xmm.epn import get_cc12_txy, get_plate_scale_xy
 
@@ -272,13 +272,23 @@ def run(path_to_cfg: Path, agn_counts_file: Path | None, spectrum_dir: Path | No
 
                     img_settings.append(settings)
 
-            kwds = (
-                {
-                    "img_settings": img_setting,
-                    "output_dir": agn_path / img_setting.pop("instrument_name"),
-                }
-                for img_setting in img_settings
-            )
+            if env_cfg.debug:
+                kwds = (
+                    {
+                        "img_settings": img_setting,
+                        "output_dir": agn_path / img_setting.pop("instrument_name"),
+                    }
+                    for img_setting in img_settings
+                )
+            else:
+                kwds = (
+                    {
+                        "img_settings": img_setting,
+                        "output_dir": agn_path / img_setting["instrument_name"],
+                    }
+                    for img_setting in img_settings
+                    for _ in range(simput_cfg.agn.n_gen)
+                )
 
             # Get the spectrum file
             spectrum_file = get_spectrumfile(run_dir=tmp_dir, norm=0.001)

--- a/03_xmm_simulation.py
+++ b/03_xmm_simulation.py
@@ -40,6 +40,9 @@ def _simulate_mode(
 
     # Find the simput files
     mode_dir = sim_cfg.simput_dir / mode
+    if mode == "agn":
+        mode_dir = mode_dir / instrument_name
+
     if mode != "bkg":
         mode_glob = mode_dir.rglob("*.simput.gz")
         simputs = []
@@ -147,6 +150,7 @@ def run(path_to_cfg: Path) -> None:
                         decompress_targz(
                             in_file_path=simput_compressed,
                             out_file_dir=sim_cfg.simput_dir / mode[0],
+                            tar_options="--strip-components=1",
                         )
                         logger.success("DONE\tDecompressing SIMPUT files.")
 

--- a/src/simput/gen/background.py
+++ b/src/simput/gen/background.py
@@ -7,13 +7,13 @@ from loguru import logger
 
 from src.simput.gen.utils import generate_ascii_spectrum, ones_like_xmm
 from src.sixte import commands
-from src.xmm.utils import get_cdelt, get_naxis12, get_surface
+from src.xmm.utils import get_cdelt, get_crpix12, get_naxis12, get_pixel_size
 
 
 def get_ascii_spectrum(
     run_dir: Path,
     spectrum_file: Path,
-    instrument_name: Literal["epn", "emos1", "emos2"],
+    surface: float,
     verbose: bool = True,
 ) -> Path:
     # Open the background spectrum file (sky + instrument + particle)
@@ -27,7 +27,6 @@ def get_ascii_spectrum(
         counts = spectrum.data["COUNTS"].astype(np.float32)
         rates = counts / float(spectrum.header["EXPOSURE"])
 
-    surface = get_surface(instrument_name=instrument_name, res_mult=1) * 1e-2  # cm**2
     cgi_rates = rates / surface  # photon/s/cm**2/keV
 
     ascii_spectrum = generate_ascii_spectrum(run_dir, energies, cgi_rates, verbose)
@@ -39,6 +38,7 @@ def background(
     run_dir: Path,
     spectrum_file: Path,
     instrument_name: Literal["epn", "emos1", "emos2"],
+    sim_separate_ccds: bool,
     emin: float,
     emax: float,
     suffix=None,
@@ -46,22 +46,25 @@ def background(
 ) -> Path:
     suffix = f"_{instrument_name}" if suffix is None else f"_{suffix}"
 
-    cdelt = get_cdelt(instrument_name=instrument_name, res_mult=1)
+    cdelt1 = get_cdelt(instrument_name=instrument_name, res_mult=1)
+    cdelt2 = -cdelt1
     naxis1, naxis2 = get_naxis12(instrument_name=instrument_name, res_mult=1)
 
-    crpix1 = round(((naxis1 + 1) / 2.0), 6)
-    crpix2 = round(((naxis1 + 1) / 2.0), 6)
+    crpix1, crpix2 = get_crpix12(instrument_name, sim_separate_ccds, 1)
 
     image_file = ones_like_xmm(
         resolution=(naxis1, naxis2),
-        cdelt=cdelt,
+        cdelt1=cdelt1,
+        cdelt2=cdelt2,
         crpix1=crpix1,
         crpix2=crpix2,
         run_dir=run_dir,
         filename=f"const_background{suffix}.fits",
     )
 
-    ascii_spectrum_file = get_ascii_spectrum(run_dir, spectrum_file, instrument_name, verbose)
+    surface = (get_pixel_size(instrument_name, 1) ** 2) * naxis1 * naxis2 * 1e-2  # cm**2
+
+    ascii_spectrum_file = get_ascii_spectrum(run_dir, spectrum_file, surface, verbose)
 
     outfile_path = run_dir / f"background{suffix}.simput"
 

--- a/src/simput/gen/generation.py
+++ b/src/simput/gen/generation.py
@@ -15,6 +15,7 @@ from src.xmm_utils.file_utils import compress_gzip
 
 def create_background(
     instrument_name: Literal["epn", "emos1", "emos2"],
+    sim_separate_ccds: bool,
     emin: float,
     emax: float,
     run_dir: Path,
@@ -25,6 +26,7 @@ def create_background(
             run_dir=run_dir,
             spectrum_file=spectrum_file,
             instrument_name=instrument_name,
+            sim_separate_ccds=sim_separate_ccds,
             emin=emin,
             emax=emax,
         )
@@ -60,7 +62,7 @@ def create_agn_sources(
             pass
 
         for i, flux in enumerate(fluxes):
-            logger.info(f"Creating AGN with flux={flux}")
+            logger.debug(f"Creating AGN with flux={flux}")
             output_file = run_dir / f"ps_{unique_id}_{i}.simput"
             output_file = simput_ps(
                 emin=emin,
@@ -68,6 +70,7 @@ def create_agn_sources(
                 output_file=output_file,
                 src_flux=flux,
                 xspec_file=xspec_file,
+                center_point=img_settings["center_point"],
                 offset="random",
             )
             simput_files.append(output_file)
@@ -102,6 +105,7 @@ def simput_generate(
                 img_settings=img_settings,
                 xspec_file=spectrum_file,
             )
+            output_dir.mkdir(parents=True, exist_ok=True)
 
         if mode == "img":
             file_names = simput_image(
@@ -124,6 +128,7 @@ def simput_generate(
                 emax=emax,
                 run_dir=run_dir,
                 spectrum_file=spectrum_file,
+                sim_separate_ccds=img_settings["sim_separate_ccds"],
             )
 
         for file_name in file_names:

--- a/src/simput/gen/utils.py
+++ b/src/simput/gen/utils.py
@@ -8,7 +8,13 @@ from loguru import logger
 
 
 def ones_like_xmm(
-    resolution: int | tuple[int, int], cdelt: float, crpix1: float, crpix2: float, run_dir: Path, filename: str
+    resolution: int | tuple[int, int],
+    cdelt1: float,
+    cdelt2: float,
+    crpix1: float,
+    crpix2: float,
+    run_dir: Path,
+    filename: str,
 ) -> Path:
     if isinstance(resolution, int):
         resolution = (resolution, resolution)
@@ -24,8 +30,8 @@ def ones_like_xmm(
         "CRVAL2": 0.0,
         "CUNIT1": "deg",
         "CUNIT2": "deg",
-        "CDELT1": cdelt,
-        "CDELT2": cdelt,
+        "CDELT1": cdelt1,
+        "CDELT2": cdelt2,
         "comment": "This fits image has all pixel value as 1 and has a similar resolution as xmm",
     }
 

--- a/src/sixte/simulator.py
+++ b/src/sixte/simulator.py
@@ -27,7 +27,7 @@ def run_simulation(
     rollangle: float = 0.0,
     sim_separate_ccds: bool = False,
     consume_data: bool = True,
-):
+) -> list[tuple[Path, int]] | None:
     xml_file = get_xml_file(
         xml_dir=xml_dir,
         instrument_name=instrument_name,
@@ -56,7 +56,13 @@ def run_simulation(
 
     evt_filepaths = []
     for evt_filepath in run_dir.glob("*_none"):
-        evt_filepaths.append(filter_event_pattern(eventlist_path=evt_filepath, max_event_pattern=max_event_pattern))
+        evt_filepath = filter_event_pattern(eventlist_path=evt_filepath, max_event_pattern=max_event_pattern)
+        if evt_filepath is not None:
+            evt_filepaths.append(evt_filepath)
+
+    if not evt_filepath:
+        logger.warning(f"No events have been detected for detector {instrument_name} for {simput_path}!")
+        return None
 
     merged = merge_ccd_eventlists(evt_filepaths, run_dir, consume_data)
 
@@ -173,6 +179,9 @@ def run_xmm_simulation(
             sim_separate_ccds=sim_separate_ccds,
             consume_data=consume_data,
         )
+
+        if tmp_split_img_paths_exps is None:
+            return
 
         for p in tmp_split_img_paths_exps:
             file_path: Path = p[0]

--- a/src/sixte/simulator.py
+++ b/src/sixte/simulator.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from src.sixte import commands
 from src.sixte.image_gen import merge_ccd_eventlists, split_eventlist
-from src.xmm.utils import get_cdelt, get_naxis12, get_xml_file
+from src.xmm.utils import get_cdelt, get_crpix12, get_naxis12, get_xml_file
 from src.xmm_utils.file_utils import compress_gzip, filter_event_pattern
 
 
@@ -79,15 +79,7 @@ def run_simulation(
     cdelt1 = get_cdelt(instrument_name=instrument_name, res_mult=res_mult)
     cdelt2 = -cdelt1
 
-    if instrument_name == "epn":
-        from src.xmm.epn import get_shift_xy
-
-        shift_y, shift_x = get_shift_xy(res_mult=res_mult)
-        crpix1 = round(((naxis1 + 1) / 2.0) - shift_x, 6)
-        crpix2 = round(((naxis2 + 1) / 2.0) + shift_y, 6)
-    else:
-        crpix1 = round(((naxis1 + 1) / 2.0), 6)
-        crpix2 = round(((naxis2 + 1) / 2.0), 6)
+    crpix1, crpix2 = get_crpix12(instrument_name, sim_separate_ccds, res_mult)
 
     img_name = f"{simput_path.name.replace('.simput.gz', '')}_mult_{res_mult}"
     split_img_paths_exps = []

--- a/src/xmm/emos.py
+++ b/src/xmm/emos.py
@@ -23,13 +23,6 @@ def get_img_width_height(emos_num: Literal[1, 2], res_mult: int = 1) -> tuple[in
     return int(size_x), int(size_y)
 
 
-def get_surface(emos_num: Literal[1, 2], res_mult: int = 1) -> float:
-    pixel_size = get_pixel_size(emos_num, res_mult)
-    width, height = get_img_width_height(emos_num, res_mult)
-
-    return (pixel_size**2) * width * height
-
-
 def get_ccd_width_height(res_mult: int = 1) -> tuple[int, int]:
     """
     Returns:

--- a/src/xmm/epn.py
+++ b/src/xmm/epn.py
@@ -23,17 +23,6 @@ def get_img_width_height(res_mult: int = 1) -> tuple[int, int]:
     return int(size_x), int(size_y)
 
 
-def get_surface(res_mult: int = 1) -> float:
-    """
-    Returns:
-        float: The surface of EPIC-pn in mm²
-    """
-    pixel_size = get_pixel_size(res_mult=res_mult)
-    x, y = get_img_width_height(res_mult=res_mult)
-
-    return (pixel_size**2) * x * y
-
-
 def get_ccd_width_height(res_mult: int = 1) -> tuple[int, int]:
     return 64 * res_mult, 200 * res_mult
 

--- a/src/xmm/utils.py
+++ b/src/xmm/utils.py
@@ -54,20 +54,6 @@ def get_pixel_size(instrument_name: str, res_mult: int) -> float:
     raise ValueError(f"Unknown instrument '{instrument_name}'! Available instruments: {available_instruments}.")
 
 
-def get_surface(instrument_name: str, res_mult: int) -> float:
-    if instrument_name == "epn":
-        from src.xmm.epn import get_surface
-
-        return get_surface(res_mult=res_mult)
-
-    if instrument_name == "emos1" or instrument_name == "emos2":
-        from src.xmm.emos import get_surface
-
-        return get_surface(emos_num=int(instrument_name[-1]), res_mult=res_mult)
-
-    raise ValueError(f"Unknown instrument '{instrument_name}'! Available instruments: {available_instruments}.")
-
-
 def get_naxis12(instrument_name: str, res_mult: int) -> tuple[int, int]:
     if instrument_name == "epn":
         from src.xmm.epn import get_naxis12
@@ -80,6 +66,22 @@ def get_naxis12(instrument_name: str, res_mult: int) -> tuple[int, int]:
         return get_naxis12(emos_num=int(instrument_name[-1]), res_mult=res_mult)
 
     raise ValueError(f"Unknown instrument '{instrument_name}'! Available instruments: {available_instruments}.")
+
+
+def get_crpix12(instrument_name: str, sim_separate_ccds: bool, res_mult: int):
+    naxis1, naxis2 = get_naxis12(instrument_name=instrument_name, res_mult=res_mult)
+
+    if instrument_name == "epn" and sim_separate_ccds:
+        from src.xmm.epn import get_shift_xy
+
+        shift_y, shift_x = get_shift_xy(res_mult=res_mult)
+        crpix1 = round(((naxis1 + 1) / 2.0) - shift_x, 6)
+        crpix2 = round(((naxis2 + 1) / 2.0) + shift_y, 6)
+    else:
+        crpix1 = round(((naxis1 + 1) / 2.0), 6)
+        crpix2 = round(((naxis2 + 1) / 2.0), 6)
+
+    return crpix1, crpix2
 
 
 def get_focal_length(instrument_name: str) -> float:

--- a/src/xmm_utils/file_utils.py
+++ b/src/xmm_utils/file_utils.py
@@ -24,12 +24,12 @@ def compress_targz(in_path: Path, out_file_path: Path, remove_files: bool = Fals
     )
 
 
-def decompress_targz(in_file_path: Path, out_file_dir: Path):
+def decompress_targz(in_file_path: Path, out_file_dir: Path, tar_options: str = ""):
     out_file_dir.mkdir(parents=True, exist_ok=True)
-    run_command(f"tar -xzf {in_file_path.resolve()} -C {out_file_dir.resolve()} --strip-components=1")
+    run_command(f"tar -xzf {in_file_path.resolve()} -C {out_file_dir.resolve()} {tar_options}")
 
 
-def filter_event_pattern(eventlist_path: Path, max_event_pattern: int):
+def filter_event_pattern(eventlist_path: Path, max_event_pattern: int) -> Path | None:
     if max_event_pattern == -1 or max_event_pattern == 12:
         # Use all event patterns
         return eventlist_path
@@ -42,6 +42,10 @@ def filter_event_pattern(eventlist_path: Path, max_event_pattern: int):
 
         # Filter the events data, remove every event with pattern type > max pattern type
         filtered_events_data = events_data[events_data["TYPE"] <= max_event_pattern]
+
+        if filtered_events_data.size == 0:
+            # No events left after filtering
+            return None
 
         # Since we filtered the events, set the patterns to 0
         for i in range(max_event_pattern + 1, 13):


### PR DESCRIPTION
When generating SIMPUT for `bkg` and `agn`, one needs to take into account whether EPN will be simulated with `sim_separate_ccds = True`. If so, the centre point has to be shifted to match the real shift of the focal point to avoid being on a gap.

Branch has been created based on #31 